### PR TITLE
Replaced Dimensions call with class variable

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,7 +27,7 @@ export default class App extends Component {
           horizontal
           snapToAlignment={'center'}
           decelerationRate={0}
-          snapToInterval={Dimensions.get('window').width}
+          snapToInterval={this.WINDOW_WIDTH}
           data={[{ key: '1' }, { key: '2' }, { key: '3' }, { key: '4' }]}
           renderItem={({ item }) => (
             <Text
@@ -38,14 +38,13 @@ export default class App extends Component {
                 marginTop: 50,
                 fontSize: 30,
                 opacity: this.state.currentPage === item.key ? 1 : 0.4
-              }}
-            >
+              }} >
               Some header {item.key}
             </Text>
           )}
         />
         <FlatList
-          ref={screenList => (this.screenList = screenList)}
+          ref={screenList => this.screenList = screenList}
           horizontal
           snapToAlignment={'center'}
           decelerationRate={0}


### PR DESCRIPTION
Having a Dimensions API call inside render is quite bad as it means RN will have to measure the width of the screen every time your component renders. I have simply replaced it with your already present `WINDOW_WIDTH` which prevents this unnecessary computation on every render.